### PR TITLE
Feature/zpool iostat mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,34 +39,53 @@ this file.
 ## Usage
 
 ```
-Usage: spindown_timer.sh [-h] [-q] [-v] [-d] [-m] [-t TIMEOUT] [-p POLL_TIME] [-i DRIVE] [-s TIMEOUT]
+Usage: spindown_timer.sh [-h] [-q] [-v] [-d] [-m] [-u MODE] [-t TIMEOUT] [-p POLL_TIME] [-i DRIVE] [-s TIMEOUT]
 
-Monitors drive I/O and forces disk spindown after a given idle period.
+Monitors drive I/O and forces HDD spindown after a given idle period.
 Resistant to S.M.A.R.T. reads.
 
-A drive is considered as idle and is spun down if there has been no I/O
-operations on it for at least TIMEOUT seconds. I/O requests are evaluated
-during intervals with a length of POLL_TIME seconds. Detected reads or
+Operation is supported on either drive level (MODE = disk) with plain device
+identifiers or zpool level (MODE = zpool) with zfs pool names. See -u for more
+information. A drive is considered idle and gets spun down if there has been no
+I/O operations on it for at least TIMEOUT seconds. I/O requests are detected
+within multiple intervals with a length of POLL_TIME seconds. Detected reads or
 writes reset the drives timer back to TIMEOUT.
 
 Options:
-  -q           : Quiet mode. Outputs are suppressed if flag is present.
-  -v           : Verbose mode. Prints additonal information during execution.
-  -d           : Dry run. No actual spindown is performed.
-  -m           : Manual mode. If this flag is set, the automatic drive detection
+  -t TIMEOUT   : Total spindown delay. Number of seconds a drive has to
+                 experience no I/O activity before it is spun down (default: 3600).
+  -p POLL_TIME : I/O poll interval. Number of seconds to wait for I/O during a
+                 single monitoring period (default: 600).
+  -s TIMEOUT   : Shutdown timeout. If given and no drive is active for TIMEOUT
+                 seconds, the system will be shut down.
+  -u MODE      : Operation mode (default: disk).
+                 If set to 'disk', the script operates with disk identifiers
+                 (e.g. ada0) for all CLI arguments and monitors I/O using
+                 iostat directly.
+                 If set to 'zpool' the script operates with ZFS pool names
+                 (e.g. zfsdata) for all CLI arguments and monitors I/O using
+                 the iostat of zpool.
+  -i DRIVE     : In automatic drive detection mode (default):
+                   Ignores the given drive or zfs pool.
+                 In manual mode [-m]:
+                   Only monitor the specified drives or zfs pools. Multiple
+                   drives or zfs pools can be given by repeating the -i option.
+  -m           : Manual drive detection mode. If set, automatic drive detection
                  is disabled.
-                 This inverts the -i switch, which then needs to be used to supply
-                 each drive to monitor. All other drives will be ignored.
-  -t TIMEOUT   : Number of seconds to wait for I/O in total before considering
-                 a drive as idle.
-  -p POLL_TIME : Number of seconds to wait for I/O during a single iostat call.
-  -i DRIVE     : In automatic drive detection mode (default): Ignores the given
-                 drive and never issue a spindown command for it.
-                 In manual mode [-m]: Only monitor the specified drives.
-                 Multiple drives can be given by repeating the -i switch.
-  -s TIMEOUT   : Shutdown timeout, if no drive is active for TIMEOUT seconds, 
-                 the system will be shut down 
+                 CAUTION: This inverts the -i option, which can then be used to
+                 manually supply drives or zfs pools to monitor. All other drives
+                 or zfs pools will be ignored.
+  -q           : Quiet mode. Outputs are suppressed set.
+  -v           : Verbose mode. Prints additional information during execution.
+  -d           : Dry run. No actual spindown is performed.
   -h           : Print this help message.
+
+Example usage:
+spindown_timer.sh
+spindown_timer.sh -q -t 3600 -p 600 -i ada0 -i ada1
+spindown_timer.sh -q -m -i ada6 -i ada7 -i da0
+spindown_timer.sh -u zpool -i freenas-boot
+
 ```
 
 ## Deployment and configuration

--- a/spindown_timer.sh
+++ b/spindown_timer.sh
@@ -34,6 +34,7 @@
 
 # TODO: Add zpool operation mode to README and update all areas that changed
 
+VERSION=2.1.0
 TIMEOUT=3600               # Default timeout before considering a drive as idle
 POLL_TIME=600              # Default time to wait during a single iostat call
 IGNORED_DRIVES=""          # Default list of drives that are never spun down
@@ -443,6 +444,7 @@ function get_drive_timeouts() {
 # Main program loop
 ##
 function main() {
+    log_verbose "Running HDD Spindown Timer version $VERSION"
     if [[ $DRYRUN -eq 1 ]]; then log "Performing a dry run..."; fi
 
     # Verify operation mode

--- a/spindown_timer.sh
+++ b/spindown_timer.sh
@@ -4,14 +4,14 @@
 # TrueNAS HDD Spindown Timer
 # Monitors drive I/O and forces HDD spindown after a given idle period.
 #
-# Version: 2.0.1
+# Version: 2.1.0
 #
 # See: https://github.com/ngandrass/truenas-spindown-timer
 #
 #
 # MIT License
 # 
-# Copyright (c) 2022 Niels Gandraß <niels@gandrass.de>
+# Copyright (c) 2023 Niels Gandraß <niels@gandrass.de>
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/spindown_timer.sh
+++ b/spindown_timer.sh
@@ -99,7 +99,7 @@ EOF
 ##
 function log() {
     if [[ $QUIET -eq 0 ]]; then
-        echo $1
+        echo "[$(date '+%F %T')] $1"
     fi
 }
 
@@ -112,7 +112,7 @@ function log() {
 function log_verbose() {
     if [[ $VERBOSE -eq 1 ]]; then
         if [[ $QUIET -eq 0 ]]; then
-            echo $1
+            echo "[$(date '+%F %T')] $1"
         fi
     fi
 }
@@ -124,7 +124,7 @@ function log_verbose() {
 #   $1 Message to write to stderr
 ##
 function log_error() {
-    >&2 echo "[ERROR]: $1"
+    >&2 echo "[$(date '+%F %T')] [ERROR]: $1"
 }
 
 ##
@@ -307,11 +307,13 @@ function spindown_drive() {
                     hdparm -q -y "/dev/$1"
                 ;;
             esac
-        fi
 
-        log "$(date '+%F %T') Spun down idle drive: $1"
+            log "Spun down idle drive: $1"
+        else
+            log "Would spin down idle drive: $1. No spindown was performed (dry run)."
+        fi
     else
-        log_verbose "$(date '+%F %T') Drive is already spun down: $1"
+        log_verbose "Drive is already spun down: $1"
     fi
 }
 
@@ -319,7 +321,7 @@ function spindown_drive() {
 # Generates a list of all active timeouts
 ##
 function get_drive_timeouts() {
-    echo -n "$(date '+%F %T') Drive timeouts: "
+    echo -n "Drive timeouts: "
     for x in "${!DRIVE_TIMEOUTS[@]}"; do printf "[%s]=%s " "$x" "${DRIVE_TIMEOUTS[$x]}" ; done
     echo ""
 }

--- a/spindown_timer.sh
+++ b/spindown_timer.sh
@@ -32,8 +32,6 @@
 # SOFTWARE.
 # ##################################################
 
-# TODO: Add zpool operation mode to README and update all areas that changed
-
 VERSION=2.1.0
 TIMEOUT=3600               # Default timeout before considering a drive as idle
 POLL_TIME=600              # Default time to wait during a single iostat call
@@ -56,7 +54,8 @@ OPERATION_MODE=disk        # Default operation mode (disk or zpool)
 ##
 function print_usage() {
     cat << EOF
-Usage: $0 [-h] [-q] [-v] [-d] [-m] [-u MODE] [-t TIMEOUT] [-p POLL_TIME] [-i DRIVE] [-s TIMEOUT]
+Usage:
+  $0 [-h] [-q] [-v] [-d] [-m] [-u <MODE>] [-t <TIMEOUT>] [-p <POLL_TIME>] [-i <DRIVE>] [-s <TIMEOUT>]
 
 Monitors drive I/O and forces HDD spindown after a given idle period.
 Resistant to S.M.A.R.T. reads.

--- a/spindown_timer.sh
+++ b/spindown_timer.sh
@@ -53,44 +53,54 @@ OPERATION_MODE=disk        # Default operation mode (disk or zpool)
 ##
 # Prints the help/usage message
 ##
-# TODO: Update argument list
-# TODO: Update description and examples
-# TODO: Pretty formatting
 function print_usage() {
     cat << EOF
-Usage: $0 [-h] [-q] [-v] [-d] [-m] [-t TIMEOUT] [-p POLL_TIME] [-i DRIVE] [-s TIMEOUT]
+Usage: $0 [-h] [-q] [-v] [-d] [-m] [-u MODE] [-t TIMEOUT] [-p POLL_TIME] [-i DRIVE] [-s TIMEOUT]
 
 Monitors drive I/O and forces HDD spindown after a given idle period.
 Resistant to S.M.A.R.T. reads.
 
-A drive is considered as idle and is spun down if there has been no I/O
-operations on it for at least TIMEOUT seconds. I/O requests are detected
-during intervals with a length of POLL_TIME seconds. Detected reads or
+Operation is supported on either drive level (MODE = disk) with plain device
+identifiers or zpool level (MODE = zpool) with zfs pool names. See -u for more
+information. A drive is considered idle and gets spun down if there has been no
+I/O operations on it for at least TIMEOUT seconds. I/O requests are detected
+within multiple intervals with a length of POLL_TIME seconds. Detected reads or
 writes reset the drives timer back to TIMEOUT.
 
 Options:
-  -q           : Quiet mode. Outputs are suppressed if flag is present.
-  -v           : Verbose mode. Prints additonal information during execution.
-  -d           : Dry run. No actual spindown is performed.
-  -m           : Manual mode. If this flag is set, the automatic drive detection
+  -t TIMEOUT   : Total spindown delay. Number of seconds a drive has to
+                 experience no I/O activity before it is spun down (default: 3600).
+  -p POLL_TIME : I/O poll interval. Number of seconds to wait for I/O during a
+                 single monitoring period (default: 600).
+  -s TIMEOUT   : Shutdown timeout. If given and no drive is active for TIMEOUT
+                 seconds, the system will be shut down.
+  -u MODE      : Operation mode (default: disk).
+                 If set to 'disk', the script operates with disk identifiers
+                 (e.g. ada0) for all CLI arguments and monitors I/O using
+                 iostat directly.
+                 If set to 'zpool' the script operates with ZFS pool names
+                 (e.g. zfsdata) for all CLI arguments and monitors I/O using
+                 the iostat of zpool.
+  -i DRIVE     : In automatic drive detection mode (default):
+                   Ignores the given drive or zfs pool.
+                 In manual mode [-m]:
+                   Only monitor the specified drives or zfs pools. Multiple
+                   drives or zfs pools can be given by repeating the -i option.
+  -m           : Manual drive detection mode. If set, automatic drive detection
                  is disabled.
-                 This inverts the -i switch which then needs to be used to supply
-                 each drive to monitor. All other drives will be ignored.
-  -t TIMEOUT   : Number of seconds to wait for I/O in total before considering
-                 a drive as idle.
-  -p POLL_TIME : Number of seconds to wait for I/O during a single iostat call.
-  -i DRIVE     : In automatic drive detection mode (default): Ignores the given
-                 drive and never issue a spindown command for it.
-                 In manual mode [-m]: Only monitor the specified drives.
-                 Multiple drives can be given by repeating the -i switch.
-  -s TIMEOUT   : Shutdown timeout, if no drive is active for TIMEOUT seconds, 
-                 the system will be shut down 
+                 CAUTION: This inverts the -i option, which can then be used to
+                 manually supply drives or zfs pools to monitor. All other drives
+                 or zfs pools will be ignored.
+  -q           : Quiet mode. Outputs are suppressed set.
+  -v           : Verbose mode. Prints additional information during execution.
+  -d           : Dry run. No actual spindown is performed.
   -h           : Print this help message.
 
 Example usage:
 $0
 $0 -q -t 3600 -p 600 -i ada0 -i ada1
 $0 -q -m -i ada6 -i ada7 -i da0
+$0 -u zpool -i freenas-boot
 EOF
 }
 


### PR DESCRIPTION
This PR intruduces a ZFS pool based operation mode.

  - A new CLI argument was introduced to switch between `disk` and `zpool` operation mode: `-u MODE`
  - When no operation mode is explicitly given, the script works in `disk` mode. This completely ignores zfs pools and works as before.
  - When operation mode is set to `zpool` by supplying `-u zpool`, the script now operates on a per-zpool basis. I/O is monitored for the pool as a whole and disks are only spun down if the complete pool was idle for a given number of seconds. ZFS pools are either detected automatically or can be supplied manually (see help text for `-i` and `-m`).
  - Drives are referenced by GPTID in zpools (at least on CORE :pray:. Cloud become a problem on SCALE or other systems since I'm not sure how reliable GPTIDs are used...). Therefore the script creates a mapping from GPTIDs to device identifiers using `glabel` to be able to spin down the drives of a pool using `camcontrol` (CORE) or `hdparm` (SCALE)

Here is an example of translating a disk-based script invocation to a zpool based one:
  - **disk**: `./spindown-timer.sh -v -t 3600 -p 600 -i da0 -i ada7`
  - **zpool**: `./spindown-timer.sh -v -t 3600 -p 600 -u zpool -i freenas-boot -i ssd`