### PR TITLE
Add option to use smartctl instead of hdparm -C, -I. Skip idle check if all drives are already sleeping. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   * Fix shutdown mode on TrueNAS SCALE
   * Improve host system detection to distinguish between TrueNAS CORE and TrueNAS SCALE
   * Simplify active drive detection
+  * Skip drive I/O detection loop if all monitored drives are already sleeping
 
 
 ## Version 2.3.0 (2024-08-26)

--- a/spindown_timer.sh
+++ b/spindown_timer.sh
@@ -636,7 +636,7 @@ function main() {
             print_drive_power_states
         fi
 
-        if all_monitored_drives_are_spun_down; then
+        if [[ $(all_monitored_drives_are_spun_down) -eq 1 ]]; then
             log_verbose "All monitored drives are already spun down, sleeping ${TIMEOUT} seconds ..."
             sleep ${TIMEOUT}
             continue

--- a/spindown_timer.sh
+++ b/spindown_timer.sh
@@ -246,7 +246,7 @@ function register_drive() {
 
     local DISK_IS_ATA
     case $DISK_PARM_TOOL in
-        "camcontrol") DISK_IS_ATA=$(camcontrol identify $drive |& grep -E "^protocol(.*)ATA");;        
+        "camcontrol") DISK_IS_ATA=$(camcontrol identify $drive |& grep -E "^protocol(.*)ATA");;
         "hdparm") 
             if [ $USE_SMARTCTL -eq 1 ]; then                              
                 DISK_IS_ATA=$(smartctl -i "/dev/$drive" |& grep -E "ATA V")
@@ -568,7 +568,7 @@ function main() {
 
     # Initially identify drives to monitor
     detect_driveid_type
-    # populate_driveid_to_dev_array
+    populate_driveid_to_dev_array
     detect_drives_$OPERATION_MODE
     for drive in ${!DRIVES[@]}; do
         log_verbose "Detected drive ${drive} as ${DRIVES[$drive]} device"
@@ -601,9 +601,7 @@ function main() {
             log_verbose "All drives are spundown, Sleeping ${TIMEOUT}"
             sleep ${TIMEOUT}
             continue      
-        else
-            log_verbose "get idle drive"
-        fi        
+        fi                 
         
         local IDLE_DRIVES=$(get_idle_drives ${POLL_TIME})
         


### PR DESCRIPTION
1. hdparm -C and/or hdparm -I may wake up some drive, so added option (-r) to use smartctl instaead of hdparm(Afaik smartctl -i does not wake up drive).

2. During main loop, all_drive_idle check looks not really worthy if all drives are sleeping already. So Added check if all drive_is_sleeping before all drive_is idle check.