### PR TITLE
Feature: Add root check on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Version X.Y.Z (YYYY-MM-DD)
+  * Exit on start if script is not run as root
+    * Root privileges are required to access the drives and programms like `camcontrol` or `hdparm`
+
+
 ## Version 2.4.0 (2025-02-07)
   * Fix shutdown mode on TrueNAS SCALE
   * Add support for using `smartctl` to interact with drives

--- a/spindown_timer.sh
+++ b/spindown_timer.sh
@@ -612,6 +612,12 @@ function main() {
     detect_host_platform
     log_verbose "Running as user: $(whoami) (UID: $(id -u))"
 
+    # Check if we are running as root
+    if [ "$EUID" -ne 0 ]; then
+        log_error "This script must be run as root. Please use sudo or run as root directly."
+        exit 1
+    fi
+
     # Setup one shot mode, if selected
     if [[ $ONESHOT_MODE -eq 1 ]]; then
         TIMEOUT=$POLL_TIME


### PR DESCRIPTION
This PR adds a check to make sure the script runs as root at startup. This is required to be able to interact with the disks as well as to gain access to used tools, e.g., `camcontrol` or `hdparm`.

Without this PR, the script will exit with the "No applicable control tool found" error, which does not really point the user to the missing privileges.