### PR TITLE
Fix drive_is_spinning function output for smartctl case

### DIFF
--- a/spindown_timer.sh
+++ b/spindown_timer.sh
@@ -523,7 +523,7 @@ function drive_is_spinning() {
             if [[ -z $(hdparm -C "/dev/$1" | grep 'standby') ]]; then echo 1; else echo 0; fi
         ;;
         "smartctl")
-            if [[ -z $(smartctl --nocheck standby -i "/dev/$1" | grep -q 'Device is in STANDBY mode') ]]; then echo 1; else echo 0; fi
+            if [[ -z $(smartctl --nocheck standby -i "/dev/$1" | grep 'Device is in STANDBY mode') ]]; then echo 1; else echo 0; fi
         ;;
     esac
 }


### PR DESCRIPTION
grep -q is quiet mode and doesn't output anything, so [[ -z $(...) ]] always evaluates to true (empty)