### PR TITLE
Fix smartctl standby detection

### DIFF
--- a/spindown_timer.sh
+++ b/spindown_timer.sh
@@ -523,7 +523,7 @@ function drive_is_spinning() {
             if [[ -z $(hdparm -C "/dev/$1" | grep 'standby') ]]; then echo 1; else echo 0; fi
         ;;
         "smartctl")
-            if [[ -z $(smartctl --nocheck standby -i "/dev/$1" | grep -q 'Device is in STANDBY mode') ]]; then echo 1; else echo 0; fi
+            if [[ -z $(smartctl --nocheck standby -i "/dev/$1" 2>&1 | grep -i 'STANDBY') ]]; then echo 1; else echo 0; fi
         ;;
     esac
 }

--- a/spindown_timer.sh
+++ b/spindown_timer.sh
@@ -523,7 +523,7 @@ function drive_is_spinning() {
             if [[ -z $(hdparm -C "/dev/$1" | grep 'standby') ]]; then echo 1; else echo 0; fi
         ;;
         "smartctl")
-            if [[ -z $(smartctl --nocheck standby -i "/dev/$1" 2>&1 | grep -i 'STANDBY') ]]; then echo 1; else echo 0; fi
+            if [[ -z $(smartctl --nocheck standby -i "/dev/$1" | grep -i 'STANDBY') ]]; then echo 1; else echo 0; fi
         ;;
     esac
 }


### PR DESCRIPTION
Ive changed the expression to just "STANDBY" instead of what it was before, and made it case insensitive.
Ive also removed the -q flag for grep, that was causing it to fail (theres another PR for this, might as well include it here).

Here is an example:

First of all, lets check the entire smartctl output:
```
root@truenas[~]# smartctl --nocheck standby -i "/dev/sda"
smartctl 7.4 2023-08-01 r5530 [x86_64-linux-6.12.15-production+truenas] (local build)
Copyright (C) 2002-23, Bruce Allen, Christian Franke, www.smartmontools.org

Device is in STANDBY BY COMMAND mode, exit(2)
```
As you can see, its in standby.


Lets run the original command:
```
root@truenas[~]# if [[ -z $(smartctl --nocheck standby -i "/dev/sda" | grep -q 'Device is in STANDBY mode') ]]; then echo 1; else echo 0; fi
1
```


Now without the q flag on grep:
```
root@truenas[~]# if [[ -z $(smartctl --nocheck standby -i "/dev/sda" | grep 'Device is in STANDBY mode') ]]; then echo 1; else echo 0; fi 
1
```

Now with a more general search:
```
root@truenas[~]# if [[ -z $(smartctl --nocheck standby -i "/dev/sda" | grep -i 'STANDBY') ]]; then echo 1; else echo 0; fi
0
```

As you can see, it works if we look for "STANDBY" and not "Device is in STANDBY mode".

Ive also considered if this will mess with the detection while the drive is active, and it will not:

```
root@truenas[~]# smartctl --nocheck standby -i "/dev/sda"
smartctl 7.4 2023-08-01 r5530 [x86_64-linux-6.12.15-production+truenas] (local build)
Copyright (C) 2002-23, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Vendor:               HGST
Product:              HUS726040AL4210
Revision:             A907
Compliance:           SPC-4
User Capacity:        4,000,787,030,016 bytes [4.00 TB]
Logical block size:   4096 bytes
LU is fully provisioned
Rotation Rate:        7200 rpm
Form Factor:          3.5 inches
Logical Unit id:      0x5000cca2430f01f8
Serial number:        
Device type:          disk
Transport protocol:   SAS (SPL-4)
Local Time is:        Thu Jun 18 12:45:11 2026 EEST
SMART support is:     Available - device has SMART capability.
SMART support is:     Enabled
Temperature Warning:  Enabled
Power mode is:        ACTIVE

root@truenas[~]# if [[ -z $(smartctl --nocheck standby -i "/dev/sda" | grep -i 'STANDBY') ]]; then echo 1; else echo 0; fi               
1
```
Result comes back as 1, as it should.